### PR TITLE
fix wikibooks url

### DIFF
--- a/src/doc/sections/0050_basics.inc
+++ b/src/doc/sections/0050_basics.inc
@@ -8,4 +8,4 @@ index.php?persons=2&objects=4+or+5&lengths=3+or+4&max=3&passesmin=1&passesmax=3
 	<li><strong>Max height:</strong><br>maximum height of throws is 3</li>
 	<li><strong>Passes:</strong><br>at least 1 and at most 3 passes</li>
 </ul>
-<p>If you need more information on symmetric passing patterns in genreal, have a look <a href="http://en.wikibooks.org/wiki/Symmetric_Passing_Patterns" target="_blank">here</a>.</p>
+<p>If you need more information on symmetric passing patterns in genreal, have a look <a href="https://en.wikibooks.org/wiki/Juggling/Symmetric_Passing_Patterns" target="_blank">here</a>.</p>

--- a/src/index.php
+++ b/src/index.php
@@ -251,7 +251,7 @@ echo "<form action='./index.php' method='get'>
   </tr>
   <tr>
    <td class='lable'>&nbsp;</td>
-   <td class='input'><a href='http://en.wikibooks.org/wiki/Symmetric_Passing_Patterns'>learn about symmetric passing</a></td>
+   <td class='input'><a href='https://en.wikibooks.org/wiki/Juggling/Symmetric_Passing_Patterns'>learn about symmetric passing</a></td>
   </tr>
  </table>
  $hidden_debug

--- a/www/sourceforge/htdocs/index.html
+++ b/www/sourceforge/htdocs/index.html
@@ -32,7 +32,7 @@ p.location {margin-left:1cm}
       To learn more about symmetric passing patterns, check out the wikibook:
      </p>
      <p class="location">
-      <a href="http://en.wikibooks.org/wiki/Symmetric_Passing_Patterns">http://en.wikibooks.org/wiki/Symmetric_Passing_Patterns</a>
+      <a href="https://en.wikibooks.org/wiki/Juggling/Symmetric_Passing_Patterns">https://en.wikibooks.org/wiki/Juggling/Symmetric_Passing_Patterns</a>
      </p>
      <p>
       Post <span class='emph'>questions, suggestions</span> and <span class='emph'>bugs</span> at the sourceforge.net project site:


### PR DESCRIPTION
the wikibooks url has changed in 2010:
https://en.wikibooks.org/w/index.php?title=Juggling%2FSymmetric_Passing_Patterns&type=revision&diff=1796872&oldid=1796871

changed the link to https as well